### PR TITLE
Support container log file rotation on Windows

### DIFF
--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"io"
-	"os"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -148,7 +147,7 @@ func (c *criService) startContainer(ctx context.Context,
 func (c *criService) createContainerLoggers(logPath string, tty bool) (stdout io.WriteCloser, stderr io.WriteCloser, err error) {
 	if logPath != "" {
 		// Only generate container log when log path is specified.
-		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
+		f, err := openContainerOutputFile(logPath)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed to create and open log file")
 		}

--- a/pkg/server/container_start_unix.go
+++ b/pkg/server/container_start_unix.go
@@ -20,3 +20,7 @@ import "github.com/containerd/containerd"
 func addOptWithNoPivotRoot(taskOpts []containerd.NewTaskOpts) []containerd.NewTaskOpts {
 	return append(taskOpts, containerd.WithNoPivotRoot)
 }
+
+func openContainerOutputFile(path string) (*os.File, error) {
+	return os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
+}

--- a/pkg/server/container_start_windows.go
+++ b/pkg/server/container_start_windows.go
@@ -15,10 +15,36 @@ limitations under the License.
 
 package server
 
-import "github.com/containerd/containerd"
+import (
+	"os"
+
+	"github.com/containerd/containerd"
+	"golang.org/x/sys/windows"
+)
 
 func addOptWithNoPivotRoot(taskOpts []containerd.NewTaskOpts) []containerd.NewTaskOpts {
 	// TODO: JTERRY75 - For LCOW we should actually forward this call all the
 	// way to the runc in the guest.
 	return taskOpts
+}
+
+func openContainerOutputFile(path string) (*os.File, error) {
+	u16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := windows.CreateFile(
+		u16,
+		windows.FILE_APPEND_DATA,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0)
+	if err != nil {
+		return nil, err
+	}
+
+	return os.NewFile(uintptr(h), path), nil
 }


### PR DESCRIPTION
Container log file rotation works by first renaming the existing log
file, then calling ReopenContainerLog to cause containerd to close the
file handle and open a new handle to the original log file path.

On Windows, the rename operation failed due to os.OpenFile not passing
the FILE_SHARE_DELETE share mode. This fixes the issue by directly
calling CreateFile on Windows, and passing FILE_SHARE_DELETE.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>