### PR TITLE
Assign ImageSpec User if SecurityContext is not set

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -114,7 +114,13 @@ func setOCINamespaces(g *generator, namespaces *runtime.NamespaceOption, sandbox
 	}
 }
 
-// generateUserString generates valid user string based on OCI Image Spec v1.0.0.
+// generateUserString generates valid user string based on OCI Image Spec
+// v1.0.0.
+//
+// CRI defines that the following combinations are valid:
+//
+// uid, uid/gid, username, username/gid
+//
 // TODO(random-liu): Add group name support in CRI.
 func generateUserString(username string, uid, gid *runtime.Int64Value) (string, error) {
 	var userstr, groupstr string

--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -220,6 +220,11 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate user string")
 	}
+	if userstr == "" {
+		// Lastly, since no user override was passed via CRI try to set via OCI
+		// Image
+		userstr = image.ImageSpec.Config.User
+	}
 	if userstr != "" {
 		specOpts = append(specOpts, oci.WithUser(userstr))
 	}

--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -370,6 +370,11 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate user string")
 		}
+		if userstr == "" {
+			// Lastly, since no user override was passed via CRI try to set via
+			// OCI Image
+			userstr = imageConfig.User
+		}
 		if userstr != "" {
 			g.AddAnnotation("io.microsoft.lcow.userstr", userstr)
 		}

--- a/pkg/server/sandbox_run_unix.go
+++ b/pkg/server/sandbox_run_unix.go
@@ -155,6 +155,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate user string")
 	}
+	if userstr == "" {
+		// Lastly, since no user override was passed via CRI try to set via OCI
+		// Image
+		userstr = image.ImageSpec.Config.User
+	}
 	if userstr != "" {
 		specOpts = append(specOpts, oci.WithUser(userstr))
 	}

--- a/pkg/server/sandbox_run_windows.go
+++ b/pkg/server/sandbox_run_windows.go
@@ -333,6 +333,11 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate user string")
 		}
+		if userstr == "" {
+			// Lastly, since no user override was passed via CRI try to set via
+			// OCI Image
+			userstr = imageConfig.User
+		}
 		if userstr != "" {
 			g.AddAnnotation("io.microsoft.lcow.userstr", userstr)
 		}


### PR DESCRIPTION
By default the SecurityContext for Container activation can contain a Username
UID, GID. The order of precedences is username, UID, GID. If none of these
options are specified as a last resort attempt to set the ImageSpec username.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>