### PR TITLE
Customizable scratch: Pass annotations to snapshottor as options

### DIFF
--- a/pkg/containerd/opts/container.go
+++ b/pkg/containerd/opts/container.go
@@ -27,14 +27,15 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/continuity/fs"
 	"github.com/pkg/errors"
 )
 
 // WithNewSnapshot wraps `containerd.WithNewSnapshot` so that if creating the
 // snapshot fails we make sure the image is actually unpacked and and retry.
-func WithNewSnapshot(id string, i containerd.Image) containerd.NewContainerOpts {
-	f := containerd.WithNewSnapshot(id, i)
+func WithNewSnapshot(id string, i containerd.Image, opts ...snapshots.Opt) containerd.NewContainerOpts {
+	f := containerd.WithNewSnapshot(id, i, opts...)
 	return func(ctx context.Context, client *containerd.Client, c *containers.Container) error {
 		if err := f(ctx, client, c); err != nil {
 			if !errdefs.IsNotFound(err) {

--- a/pkg/server/sandbox_run_windows.go
+++ b/pkg/server/sandbox_run_windows.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/containerd/snapshots"
 	"github.com/davecgh/go-spew/spew"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -165,11 +166,12 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	log.G(ctx).Debugf("Sandbox container %q spec: %#+v", id, spew.NewFormatter(spec))
 
 	sandboxLabels := buildLabels(config.Labels, containerKindSandbox)
+	snapshotterOpt := snapshots.WithLabels(config.Annotations)
 
 	opts := []containerd.NewContainerOpts{
 		containerd.WithImage(image.Image),
 		containerd.WithSnapshotter(c.getDefaultSnapshotterForPlatform(sandboxPlatform)),
-		customopts.WithNewSnapshot(id, image.Image),
+		customopts.WithNewSnapshot(id, image.Image, snapshotterOpt),
 		containerd.WithContainerLabels(sandboxLabels),
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),
 		containerd.WithSpec(spec),


### PR DESCRIPTION
This change passes the annotations to containerd snapshotters as options. Snapshotters can use those annotations in any way they want. LCOW snapshotter passes couple of these annotations to hcsshim which uses it to determine the size and location of scratch vhd.