### PR TITLE
correctly set no new privs value in container spec

### DIFF
--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -438,6 +438,7 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 			g.AddProcessAdditionalGid(uint32(group))
 		}
 		setOCINamespaces(&g, securityContext.GetNamespaceOptions(), sandboxPid)
+		g.SetProcessNoNewPrivileges(securityContext.GetNoNewPrivs())
 	} else {
 		username := config.GetWindows().GetSecurityContext().GetRunAsUsername()
 		if username != "" {


### PR DESCRIPTION
Quick fix to correctly set the NoNewPrivs value from the security context on the container spec in the lcow scenario. 

Signed-off-by: Kathryn Baldauf kabaldau@microsoft.com