### PR TITLE
Forward SandboxConfig.Hostname to Workload container activation

### DIFF
--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -284,6 +284,11 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 	// Set the Network Namespace
 	g.SetWindowsNetworkNamespace(netnsPath)
 
+	if sandboxPlatform == "windows/amd64" {
+		// Set the container hostname
+		g.SetHostname(sandboxConfig.GetHostname())
+	}
+
 	// Forward any annotations from the orchestrator
 	for k, v := range config.Annotations {
 		g.AddAnnotation(k, v)


### PR DESCRIPTION
1. For Windows the Hostname property is not inherited from the sandbox and must
be passed for the Workload container activations as well.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>