### PR TITLE
Add mount propagation support

### DIFF
--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -311,6 +311,21 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 		var options []string
 		if sandboxPlatform == "linux/amd64" {
 			options = append(options, "rbind")
+			switch m.GetPropagation() {
+			case runtime.MountPropagation_PROPAGATION_PRIVATE:
+				options = append(options, "rprivate")
+			case runtime.MountPropagation_PROPAGATION_BIDIRECTIONAL:
+				options = append(options, "rshared")
+				g.SetLinuxRootPropagation("rshared")
+			case runtime.MountPropagation_PROPAGATION_HOST_TO_CONTAINER:
+				options = append(options, "rslave")
+				if g.Config.Linux.RootfsPropagation != "rshared" {
+					g.SetLinuxRootPropagation("rslave")
+				}
+			default:
+				log.G(ctx).Warnf("Unknown propagation mode %v for hostPath %q, defaulting to rprivate", m.GetPropagation(), src)
+				options = append(options, "rprivate")
+			}
 		}
 
 		if m.GetReadonly() {


### PR DESCRIPTION
Add the ability to set the mount propagation of a given mount and the mount propagation of the container's root fs. 
Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>