### PR TITLE
Don't panic when processing nil stats

### DIFF
--- a/pkg/server/container_stats_list_windows.go
+++ b/pkg/server/container_stats_list_windows.go
@@ -76,18 +76,20 @@ func (c *criService) getSandboxMetrics(
 			Annotations: meta.Config.GetAnnotations(),
 		},
 	}
-	v, err := typeurl.UnmarshalAny(stats.Data)
-	if err != nil {
-		return nil, err
-	}
-	if s, ok := v.(*runhcsstats.Statistics); ok {
-		cs.Cpu = &runtime.CpuUsage{
-			Timestamp:            stats.Timestamp.UnixNano(),
-			UsageCoreNanoSeconds: &runtime.UInt64Value{s.VM.Processor.TotalRuntimeNS},
+	if stats != nil {
+		v, err := typeurl.UnmarshalAny(stats.Data)
+		if err != nil {
+			return nil, err
 		}
-		cs.Memory = &runtime.MemoryUsage{
-			Timestamp:       stats.Timestamp.UnixNano(),
-			WorkingSetBytes: &runtime.UInt64Value{s.VM.Memory.WorkingSetBytes},
+		if s, ok := v.(*runhcsstats.Statistics); ok {
+			cs.Cpu = &runtime.CpuUsage{
+				Timestamp:            stats.Timestamp.UnixNano(),
+				UsageCoreNanoSeconds: &runtime.UInt64Value{s.VM.Processor.TotalRuntimeNS},
+			}
+			cs.Memory = &runtime.MemoryUsage{
+				Timestamp:       stats.Timestamp.UnixNano(),
+				WorkingSetBytes: &runtime.UInt64Value{s.VM.Memory.WorkingSetBytes},
+			}
 		}
 	}
 	return cs, nil


### PR DESCRIPTION
Signed-off-by: Kevin Parsons <kevpar@microsoft.com>

I noticed this issue when attempting to query stats for a wcow-hypervisor pod. If no metrics were returned (e.g. if an error occurred), `getSandboxMetrics` will still be called, but with a nil stats value.