### PR TITLE
Properly forward ContainerResources to OCI spec

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -89,6 +89,37 @@ func clearReadOnly(m *runtimespec.Mount) {
 	m.Options = append(opt, "rw")
 }
 
+// setOCILinuxResourceCgroup set container cgroup resource limit.
+func setOCILinuxResourceCgroup(g *generator, resources *runtime.LinuxContainerResources) {
+	if resources == nil {
+		return
+	}
+	g.SetLinuxResourcesCPUPeriod(uint64(resources.GetCpuPeriod()))
+	g.SetLinuxResourcesCPUQuota(resources.GetCpuQuota())
+	g.SetLinuxResourcesCPUShares(uint64(resources.GetCpuShares()))
+	g.SetLinuxResourcesMemoryLimit(resources.GetMemoryLimitInBytes())
+	g.SetLinuxResourcesCPUCpus(resources.GetCpusetCpus())
+	g.SetLinuxResourcesCPUMems(resources.GetCpusetMems())
+}
+
+// setOCILinuxResourceOOMScoreAdj set container OOMScoreAdj resource limit.
+func setOCILinuxResourceOOMScoreAdj(g *generator, resources *runtime.LinuxContainerResources, restrictOOMScoreAdjFlag bool) error {
+	if resources == nil {
+		return nil
+	}
+	adj := int(resources.GetOomScoreAdj())
+	if restrictOOMScoreAdjFlag {
+		var err error
+		adj, err = restrictOOMScoreAdj(adj)
+		if err != nil {
+			return err
+		}
+	}
+	g.SetProcessOOMScoreAdj(adj)
+
+	return nil
+}
+
 func setOCIBindMountsPrivileged(g *generator) {
 	spec := g.Config
 	// clear readonly for /sys and cgroup

--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/contrib/apparmor"
 	"github.com/containerd/containerd/contrib/seccomp"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
 	"github.com/davecgh/go-spew/spew"
@@ -39,7 +40,6 @@ import (
 	"github.com/opencontainers/runtime-tools/validate"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/syndtr/gocapability/capability"
 	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
@@ -688,37 +688,6 @@ func (c *criService) addOCIBindMounts(g *generator, mounts []*runtime.Mount, mou
 			Options:     options,
 		})
 	}
-
-	return nil
-}
-
-// setOCILinuxResourceCgroup set container cgroup resource limit.
-func setOCILinuxResourceCgroup(g *generator, resources *runtime.LinuxContainerResources) {
-	if resources == nil {
-		return
-	}
-	g.SetLinuxResourcesCPUPeriod(uint64(resources.GetCpuPeriod()))
-	g.SetLinuxResourcesCPUQuota(resources.GetCpuQuota())
-	g.SetLinuxResourcesCPUShares(uint64(resources.GetCpuShares()))
-	g.SetLinuxResourcesMemoryLimit(resources.GetMemoryLimitInBytes())
-	g.SetLinuxResourcesCPUCpus(resources.GetCpusetCpus())
-	g.SetLinuxResourcesCPUMems(resources.GetCpusetMems())
-}
-
-// setOCILinuxResourceOOMScoreAdj set container OOMScoreAdj resource limit.
-func setOCILinuxResourceOOMScoreAdj(g *generator, resources *runtime.LinuxContainerResources, restrictOOMScoreAdjFlag bool) error {
-	if resources == nil {
-		return nil
-	}
-	adj := int(resources.GetOomScoreAdj())
-	if restrictOOMScoreAdjFlag {
-		var err error
-		adj, err = restrictOOMScoreAdj(adj)
-		if err != nil {
-			return err
-		}
-	}
-	g.SetProcessOOMScoreAdj(adj)
 
 	return nil
 }

--- a/pkg/server/sandbox_run_windows.go
+++ b/pkg/server/sandbox_run_windows.go
@@ -324,6 +324,15 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 	g.SetHostname(config.GetHostname())
 
 	if sandboxPlatform == "linux/amd64" {
+		// Set cgroups parent.
+		if c.config.DisableCgroup {
+			g.SetLinuxCgroupsPath("")
+		} else {
+			if config.GetLinux().GetCgroupParent() != "" {
+				return nil, errors.New("lcow does not support custom cgroup parents")
+			}
+		}
+
 		g.SetProcessUsername(imageConfig.User)
 
 		securityContext := config.GetLinux().GetSecurityContext()


### PR DESCRIPTION
Previously Linux/WindowsContainerResources were only supported via annotations.
This now enables the use of these via the actual CRI API.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>