### PR TITLE
Add support for PullImage platform from sandbox metadata

### DIFF
--- a/pkg/registrar/registrar.go
+++ b/pkg/registrar/registrar.go
@@ -100,3 +100,10 @@ func (r *Registrar) ReleaseByKey(key string) {
 	delete(r.nameToKey, name)
 	delete(r.keyToName, key)
 }
+
+func (r *Registrar) GetIDFromName(name string) string {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return r.nameToKey[name]
+}


### PR DESCRIPTION
If the PullImage.SandboxConfig does not have the sandbox-platform tag attempt
to add the platform tag by looking up the sandbox that matches the
PullImage.SandboxConfig.Metadata name.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>