### PR TITLE
Fix store error serialization to gRPC status codes

### DIFF
--- a/pkg/store/errors.go
+++ b/pkg/store/errors.go
@@ -16,12 +16,18 @@ limitations under the License.
 
 package store
 
-import "errors"
+import "github.com/containerd/containerd/errdefs"
 
 var (
 	// ErrAlreadyExist is the error returned when data added in the store
 	// already exists.
-	ErrAlreadyExist = errors.New("already exists")
+	//
+	// This error has been DEPRECATED and will be removed in 1.5. Please switch
+	// usage directly to `errdefs.ErrAlreadyExists`.
+	ErrAlreadyExist = errdefs.ErrAlreadyExists
 	// ErrNotExist is the error returned when data is not in the store.
-	ErrNotExist = errors.New("does not exist")
+	//
+	// This error has been DEPRECATED and will be removed in 1.5. Please switch
+	// usage directly to `errdefs.ErrNotFound`.
+	ErrNotExist = errdefs.ErrNotFound
 )

--- a/pkg/store/errors_test.go
+++ b/pkg/store/errors_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/containerd/containerd/errdefs"
+)
+
+func TestStoreErrAlreadyExistGRPCStatus(t *testing.T) {
+	err := errdefs.ToGRPC(ErrAlreadyExist)
+	s, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("failed to convert err: %v to status: %d", err, codes.AlreadyExists)
+	}
+	if s.Code() != codes.AlreadyExists {
+		t.Fatalf("expected code: %d got: %d", codes.AlreadyExists, s.Code())
+	}
+}
+
+func TestStoreErrNotExistGRPCStatus(t *testing.T) {
+	err := errdefs.ToGRPC(ErrNotExist)
+	s, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("failed to convert err: %v to status: %d", err, codes.NotFound)
+	}
+	if s.Code() != codes.NotFound {
+		t.Fatalf("expected code: %d got: %d", codes.NotFound, s.Code())
+	}
+}


### PR DESCRIPTION
The pkg/store errors are duplicated errors of NotFound and AlreadyExist from
containerd's errdefs package and thus do not properly serialize when running
errdefs.ToGRPC on them. CRI runs this function on every return from a CRI
method so the conversion fails if there is a cache miss from the store caches
for containers or sandboxes. This change verifies that the errors are properly
converted to their gRPC values.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>