### PR TITLE
Add option to disable http2 for registry resolver operations

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,8 @@ type Registry struct {
 	// Auths are registry endpoint to auth config mapping. The registry endpoint must
 	// be a valid url with host specified.
 	Auths map[string]AuthConfig `toml:"auths" json:"auths"`
+	// DisableHTTP2 disables http2 for the image pull resolver.
+	DisableHTTP2 bool `toml:"disable_http2" json:"disableHTTP2"`
 }
 
 // PluginConfig contains toml config related to CRI plugin,

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -255,6 +256,12 @@ func (c *criService) getResolver(ctx context.Context, ref string, cred func(stri
 	if err != nil {
 		return nil, imagespec.Descriptor{}, errors.Wrap(err, "parse image reference")
 	}
+	client := &http.Client{CheckRedirect: checkRedirecter(ctx)}
+	if c.config.Registry.DisableHTTP2 {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
+		client.Transport = transport
+	}
 	// Try mirrors in order first, and then try default host name.
 	for _, e := range c.config.Registry.Mirrors[refspec.Hostname()].Endpoints {
 		u, err := url.Parse(e)
@@ -262,8 +269,8 @@ func (c *criService) getResolver(ctx context.Context, ref string, cred func(stri
 			return nil, imagespec.Descriptor{}, errors.Wrapf(err, "parse registry endpoint %q", e)
 		}
 		resolver := docker.NewResolver(docker.ResolverOptions{
-			Authorizer: docker.NewAuthorizer(http.DefaultClient, cred),
-			Client:     http.DefaultClient,
+			Authorizer: docker.NewAuthorizer(client, cred),
+			Client:     client,
 			Host:       func(string) (string, error) { return u.Host, nil },
 			// By default use "https".
 			PlainHTTP: u.Scheme == "http",
@@ -273,9 +280,6 @@ func (c *criService) getResolver(ctx context.Context, ref string, cred func(stri
 			return resolver, desc, nil
 		}
 		// Continue to try next endpoint
-	}
-	client := &http.Client{
-		CheckRedirect: checkRedirecter(ctx),
 	}
 	resolver := docker.NewResolver(docker.ResolverOptions{
 		Credentials: cred,


### PR DESCRIPTION
* Added DisableHTTP2 boolean option to cri registry config. When set
will disable http2 for the image pull resolvers http operations.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>