### PR TITLE
Re-implement "No HTTP2" support using "GODEBUG=http2client=0"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -157,6 +157,8 @@ type PluginConfig struct {
 	//
 	// NOTE: JTERRY75 - This is a hack! DO not submit as the final solution.
 	AutoManageVHDTemplatePath string `toml:"auto_manage_vhd_template_path" json:"autoManageVHDTemplatePath"`
+	// Sets GODEBUG=http2client=0 if enabled.
+	DisableHTTP2Client bool `toml:"disable_http2_client" json:"disableHTTP2Client"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,8 +108,6 @@ type Registry struct {
 	// Auths are registry endpoint to auth config mapping. The registry endpoint must
 	// be a valid url with host specified.
 	Auths map[string]AuthConfig `toml:"auths" json:"auths"`
-	// DisableHTTP2 disables http2 for the image pull resolver.
-	DisableHTTP2 bool `toml:"disable_http2" json:"disableHTTP2"`
 }
 
 // PluginConfig contains toml config related to CRI plugin,

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	osruntime "runtime"
 	"time"
@@ -114,6 +115,16 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 		sandboxNameIndex:   registrar.NewRegistrar(),
 		containerNameIndex: registrar.NewRegistrar(),
 		initialized:        atomic.NewBool(false),
+	}
+
+	if c.config.DisableHTTP2Client {
+		env := "http2client=0"
+		if current := os.Getenv("GODEBUG"); current != "" {
+			env = current + "," + env
+		}
+		if err := os.Setenv("GODEBUG", env); err != nil {
+			return nil, errors.Wrap(err, "failed to set GODEBUG environment variable")
+		}
 	}
 
 	c.apparmorEnabled = isApparmorEnabled() && !config.DisableApparmor


### PR DESCRIPTION
This PR takes a new approach to disabling HTTP2 for image pulls.
Previously, we implemented this by modifying the net/http.Client used
for image pulls so that HTTP2 was disabled. However, this was found to
be fragile, and caused image pull failures in some cases. It wasn't
clear how to fully fix those issues.

Now, we will disable the HTTP2 client process-wide by setting the
GODEBUG environment variable to "http2client=0". If GODEBUG already has
a value set, we will append the new option to the end. The config file
option has now been moved to the PluginConfig section, to better
represent that this is process-wide.