### PR TITLE
Add customer logging support

### DIFF
--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -197,6 +197,8 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 
 	containerIO, err := cio.NewContainerIO(id,
+		meta.LogPath,
+		meta.Config.Labels,
 		cio.WithNewFIFOs(volatileContainerRootDir, config.GetTty(), config.GetStdin()))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create container io")

--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -189,7 +189,10 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 
 	containerIO, err := cio.NewContainerIO(id,
+		meta.LogPath,
+		meta.Config.Labels,
 		cio.WithNewFIFOs(volatileContainerRootDir, config.GetTty(), config.GetStdin()))
+
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create container io")
 	}

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -83,13 +83,17 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 	}
 
 	ioCreation := func(id string) (_ containerdio.IO, err error) {
-		stdoutWC, stderrWC, err := c.createContainerLoggers(meta.LogPath, config.GetTty())
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create container loggers")
+		if cntr.IO.LoggerSchema == cio.SchemaBinary {
+			return cntr.IO, nil
+		} else {
+			stdoutWC, stderrWC, err := c.createContainerLoggers(meta.LogPath, config.GetTty())
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create container loggers")
+			}
+			cntr.IO.AddOutput("log", stdoutWC, stderrWC)
+			cntr.IO.Pipe()
+			return cntr.IO, nil
 		}
-		cntr.IO.AddOutput("log", stdoutWC, stderrWC)
-		cntr.IO.Pipe()
-		return cntr.IO, nil
 	}
 
 	ctrInfo, err := container.Info(ctx)

--- a/pkg/server/io/helpers_unix.go
+++ b/pkg/server/io/helpers_unix.go
@@ -72,3 +72,7 @@ func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 		cancel: cancel,
 	}, nil
 }
+
+func newBinaryLogger(_ string, _ *cio.FIFOSet, _ string, , _ map[string]string) (_ *wgCloser, _ error) {
+	return nil, errors.New("not implemented")
+}

--- a/pkg/server/io/helpers_windows.go
+++ b/pkg/server/io/helpers_windows.go
@@ -253,7 +253,7 @@ func newBinaryLogger(id string, fifos *cio.FIFOSet, binaryPath string, labels ma
 	}
 
 	labelStr := string(labelData)
-	cmd := exec.Command(binaryPath, fifos.Stdout, fifos.Stderr, signalFileName, labelStr)
+	cmd := exec.Command(binaryPath, fifos.Stdout, fifos.Stderr, signalFileName, id, labelStr)
 
 	if err := cmd.Start(); err != nil {
 		return nil, err

--- a/pkg/server/io/helpers_windows.go
+++ b/pkg/server/io/helpers_windows.go
@@ -19,9 +19,15 @@ limitations under the License.
 package io
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
+	"os"
+	"os/exec"
 	"sync"
+	"time"
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/containerd/containerd/cio"
@@ -29,6 +35,9 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
+
+const binaryIOProcStartTimeout = 10 * time.Second
+const binaryIOProcTermTimeout = 10 * time.Second // Give logger process solid 10 seconds for cleanup
 
 type delayedConnection struct {
 	l    net.Listener
@@ -177,4 +186,111 @@ func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 		ctx:    ctx,
 		cancel: cancel,
 	}, nil
+}
+
+type binaryCloser struct {
+	cmd            *exec.Cmd
+	signalFileName string
+}
+
+func (this *binaryCloser) Close() error {
+	if this.cmd == nil || this.cmd.Process == nil {
+		return nil
+	}
+
+	os.Remove(this.signalFileName)
+
+	done := make(chan error, 1)
+	defer close(done)
+
+	go func() {
+		done <- this.cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(binaryIOProcTermTimeout):
+		log.L.Warn("failed to wait for customer logger process to exit, killing")
+
+		err := this.cmd.Process.Kill()
+		if err != nil {
+			return errors.Wrap(err, "failed to kill customer logger process")
+		}
+
+		return nil
+	}
+}
+
+func newBinaryLogger(id string, fifos *cio.FIFOSet, binaryPath string, labels map[string]string) (_ *wgCloser, err error) {
+	var (
+		set         []io.Closer
+		ctx, cancel = context.WithCancel(context.Background())
+	)
+
+	started := make(chan bool)
+	defer close(started)
+
+	defer func() {
+		if err != nil {
+			for _, f := range set {
+				f.Close()
+			}
+			cancel()
+		}
+	}()
+
+	signalFileName, err := getSignalFileName(id)
+	if err != nil {
+		log.L.WithError(err).Errorf("failed to create tempory signal file %s", signalFileName)
+		return nil, err
+	}
+
+	labelData, err := json.Marshal(labels)
+	if err != nil {
+		log.L.WithError(err).Errorf("failed to serialize labels")
+		return
+	}
+
+	labelStr := string(labelData)
+	cmd := exec.Command(binaryPath, fifos.Stdout, fifos.Stderr, signalFileName, labelStr)
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		for start := time.Now(); time.Now().Sub(start) < binaryIOProcStartTimeout; {
+			if _, err := os.Stat(signalFileName); os.IsNotExist(err) {
+				time.Sleep(time.Second / 2)
+			} else {
+				started <- true
+				return
+			}
+		}
+		started <- false
+	}()
+
+	// Wait until the logger started
+	if !<-started {
+		log.L.WithError(err).Errorf("failed to create signal file %s", signalFileName)
+		return nil, err
+	}
+
+	set = append(set, &binaryCloser{
+		cmd:            cmd,
+		signalFileName: signalFileName,
+	})
+
+	return &wgCloser{
+		wg:     &sync.WaitGroup{},
+		set:    set,
+		ctx:    ctx,
+		cancel: cancel,
+	}, nil
+}
+
+func getSignalFileName(id string) (string, error) {
+	tempdir, err := ioutil.TempDir("", id)
+	return fmt.Sprintf("%s\\logsignal-%s", tempdir, id), err
 }


### PR DESCRIPTION
The change add customer logging support for cri container in windows platform. it extend the existing log_path property of the container definition. and make it support binary protocal (containerd have similar impementaion in linux plat). 

for example now you can define in your contianerdef.json file
    "log_path": "binary:d:\\gosrc\\bin\\logger.exe" 
at the time the container get create, the logger is launched automatically. today we use a fixed protocal for the logger, it will require following parameters
[stdout-pipename] [stderr-pipename] [liftime-signal-filename] [containerid] [labels]

the two named pipe is require to be host to receive the log pull out from hcsshim. and lifetime-signal] file is required to be create by the logger, and the logger then take responsible to watch the file, once the containerd shutdownt he container, it will delete the file, and logger take responsible to shutdown at that time. containerd will wait at most 10s to wait for logger shutdown, if not, it will kill the logger. 

the other two parmeter is used to pass information into the customer logger.


