### PR TITLE
Fix Windows containers for Docker images relying on ArgsEscaped

### DIFF
--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -160,7 +160,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		sandboxPlatform = "windows/amd64"
 	}
 
-	spec, err := c.generateContainerSpec(id, sandboxID, sandboxPid, sandbox.NetNSPath, config, sandboxConfig, sandboxPlatform, &image.ImageSpec.Config)
+	spec, err := c.generateContainerSpec(id, sandboxID, sandboxPid, sandbox.NetNSPath, config, sandboxConfig, sandboxPlatform, &image.ImageSpec)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate container %q spec", id)
 	}
@@ -253,7 +253,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 }
 
 func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxPid uint32, netnsPath string, config *runtime.ContainerConfig,
-	sandboxConfig *runtime.PodSandboxConfig, sandboxPlatform string, imageConfig *imagespec.ImageConfig) (*runtimespec.Spec, error) {
+	sandboxConfig *runtime.PodSandboxConfig, sandboxPlatform string, image *imagespec.Image) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	ctx := ctrdutil.NamespacedContext()
 	spec, err := oci.GenerateSpecWithPlatform(ctx, nil, sandboxPlatform, &containers.Container{ID: id})
@@ -267,14 +267,14 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 	}
 	g := newSpecGenerator(spec)
 
-	if err := setOCIProcessArgs(&g, config, imageConfig); err != nil {
+	if err := setOCIProcessArgs(&g, config, image); err != nil {
 		return nil, err
 	}
 
 	if config.GetWorkingDir() != "" {
 		g.SetProcessCwd(config.GetWorkingDir())
-	} else if imageConfig.WorkingDir != "" {
-		g.SetProcessCwd(imageConfig.WorkingDir)
+	} else if image.Config.WorkingDir != "" {
+		g.SetProcessCwd(image.Config.WorkingDir)
 	}
 
 	g.SetProcessTerminal(config.GetTty())
@@ -287,7 +287,7 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 
 	// Apply envs from image config first, so that envs from container config
 	// can override them.
-	if err := addImageEnvs(&g, imageConfig.Env); err != nil {
+	if err := addImageEnvs(&g, image.Config.Env); err != nil {
 		return nil, err
 	}
 	for _, e := range config.GetEnvs() {
@@ -486,7 +486,7 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 		if userstr == "" {
 			// Lastly, since no user override was passed via CRI try to set via
 			// OCI Image
-			userstr = imageConfig.User
+			userstr = image.Config.User
 		}
 		if userstr != "" {
 			g.AddAnnotation("io.microsoft.lcow.userstr", userstr)
@@ -524,7 +524,7 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 			g.SetWindowsResourcesMemoryLimit(uint64(resources.GetMemoryLimitInBytes()))
 		}
 
-		username := imageConfig.User
+		username := image.Config.User
 		securityContext := config.GetWindows().GetSecurityContext()
 		if securityContext != nil {
 			runAsUser := securityContext.GetRunAsUsername()

--- a/vendor.conf
+++ b/vendor.conf
@@ -38,7 +38,7 @@ github.com/Microsoft/hcsshim 936eeeb286fd1197f107acfc4c3c82e4a9afc2c8
 github.com/modern-go/concurrent 1.0.3
 github.com/modern-go/reflect2 1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
-github.com/opencontainers/image-spec v1.0.1
+github.com/opencontainers/image-spec deb02d24daef68ac4a88d8f9883ba03b75bdc187 https://github.com/kevpar/image-spec.git # fork
 github.com/opencontainers/runc 12f6a991201fdb8f82579582d5e00e28fba06d0a
 github.com/opencontainers/runtime-spec v1.0.2
 github.com/opencontainers/runtime-tools 1d69bd0f9c39677d0630e50664fbc3154ae61b88

--- a/vendor.conf
+++ b/vendor.conf
@@ -40,7 +40,7 @@ github.com/modern-go/reflect2 1.0.1
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
 github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/runc 12f6a991201fdb8f82579582d5e00e28fba06d0a
-github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353
+github.com/opencontainers/runtime-spec v1.0.2
 github.com/opencontainers/runtime-tools 1d69bd0f9c39677d0630e50664fbc3154ae61b88
 github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a
 github.com/pkg/errors v0.9.1

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/config.go
@@ -48,6 +48,11 @@ type ImageConfig struct {
 
 	// StopSignal contains the system call signal that will be sent to the container to exit.
 	StopSignal string `json:"StopSignal,omitempty"`
+
+	// ArgsEscaped is a non-standard extension that was introduced by Docker. It is used for
+	// Windows images to indicate that the command has already been escaped and should be
+	// used directly as the command line.
+	ArgsEscaped bool `json:"ArgsEscaped,omitempty"`
 }
 
 // RootFS describes a layer content addresses

--- a/vendor/github.com/opencontainers/runtime-spec/README.md
+++ b/vendor/github.com/opencontainers/runtime-spec/README.md
@@ -12,7 +12,6 @@ Additional documentation about how this group operates:
 - [Style and Conventions](style.md)
 - [Implementations](implementations.md)
 - [Releases](RELEASES.md)
-- [project](project.md)
 - [charter][charter]
 
 ## Use Cases
@@ -54,11 +53,9 @@ When in doubt, start on the [mailing-list](#mailing-list).
 
 ### Meetings
 
-The contributors and maintainers of all OCI projects have monthly meetings, which are usually at 2:00 PM (USA Pacific) on the first Wednesday of every month.
-There is an [iCalendar][rfc5545] format for the meetings [here](meeting.ics).
-Everyone is welcome to participate via [UberConference web][uberconference] or audio-only: +1 415 968 0849 (no PIN needed).
-An initial agenda will be posted to the [mailing list](#mailing-list) in the week before each meeting, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes], with minutes from especially old meetings (September 2015 and earlier) archived [here][runtime-wiki].
+Please see the [OCI org repository README](https://github.com/opencontainers/org#meetings) for the most up-to-date
+information on OCI contributor and maintainer meeting schedules. You can also find links to meeting agendas and
+minutes for all prior meetings.
 
 ### Mailing List
 
@@ -139,7 +136,7 @@ Read more on [How to Write a Git Commit Message][how-to-git-commit] or the Discu
 
 
 [charter]: https://www.opencontainers.org/about/governance
-[code-of-conduct]: https://github.com/opencontainers/tob/blob/master/code-of-conduct.md
+[code-of-conduct]: https://github.com/opencontainers/org/blob/master/CODE_OF_CONDUCT.md
 [dev-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
 [how-to-git-commit]: http://chris.beams.io/posts/git-commit
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -38,7 +38,9 @@ type Process struct {
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
-	Args []string `json:"args"`
+	Args []string `json:"args,omitempty"`
+	// CommandLine specifies the full command line for the application to execute on Windows.
+	CommandLine string `json:"commandLine,omitempty" platform:"windows"`
 	// Env populates the process environment for the process.
 	Env []string `json:"env,omitempty"`
 	// Cwd is the current working directory for the process and must be
@@ -87,6 +89,8 @@ type User struct {
 	UID uint32 `json:"uid" platform:"linux,solaris"`
 	// GID is the group id.
 	GID uint32 `json:"gid" platform:"linux,solaris"`
+	// Umask is the umask for the init process.
+	Umask uint32 `json:"umask,omitempty" platform:"linux,solaris"`
 	// AdditionalGids are additional group ids set for the container's process.
 	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
 	// Username is the user name.
@@ -121,13 +125,26 @@ type Hook struct {
 	Timeout *int     `json:"timeout,omitempty"`
 }
 
+// Hooks specifies a command that is run in the container at a particular event in the lifecycle of a container
 // Hooks for container setup and teardown
 type Hooks struct {
-	// Prestart is a list of hooks to be run before the container process is executed.
+	// Prestart is Deprecated. Prestart is a list of hooks to be run before the container process is executed.
+	// It is called in the Runtime Namespace
 	Prestart []Hook `json:"prestart,omitempty"`
+	// CreateRuntime is a list of hooks to be run after the container has been created but before pivot_root or any equivalent operation has been called
+	// It is called in the Runtime Namespace
+	CreateRuntime []Hook `json:"createRuntime,omitempty"`
+	// CreateContainer is a list of hooks to be run after the container has been created but before pivot_root or any equivalent operation has been called
+	// It is called in the Container Namespace
+	CreateContainer []Hook `json:"createContainer,omitempty"`
+	// StartContainer is a list of hooks to be run after the start operation is called but before the container process is started
+	// It is called in the Container Namespace
+	StartContainer []Hook `json:"startContainer,omitempty"`
 	// Poststart is a list of hooks to be run after the container process is started.
+	// It is called in the Runtime Namespace
 	Poststart []Hook `json:"poststart,omitempty"`
 	// Poststop is a list of hooks to be run after the container process exits.
+	// It is called in the Runtime Namespace
 	Poststop []Hook `json:"poststop,omitempty"`
 }
 
@@ -160,9 +177,11 @@ type Linux struct {
 	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
 	// MountLabel specifies the selinux context for the mounts in the container.
 	MountLabel string `json:"mountLabel,omitempty"`
-	// IntelRdt contains Intel Resource Director Technology (RDT) information
-	// for handling resource constraints (e.g., L3 cache) for the container
+	// IntelRdt contains Intel Resource Director Technology (RDT) information for
+	// handling resource constraints (e.g., L3 cache, memory bandwidth) for the container
 	IntelRdt *LinuxIntelRdt `json:"intelRdt,omitempty"`
+	// Personality contains configuration for the Linux personality syscall
+	Personality *LinuxPersonality `json:"personality,omitempty"`
 }
 
 // LinuxNamespace is the configuration for a Linux namespace
@@ -181,17 +200,17 @@ const (
 	// PIDNamespace for isolating process IDs
 	PIDNamespace LinuxNamespaceType = "pid"
 	// NetworkNamespace for isolating network devices, stacks, ports, etc
-	NetworkNamespace = "network"
+	NetworkNamespace LinuxNamespaceType = "network"
 	// MountNamespace for isolating mount points
-	MountNamespace = "mount"
+	MountNamespace LinuxNamespaceType = "mount"
 	// IPCNamespace for isolating System V IPC, POSIX message queues
-	IPCNamespace = "ipc"
+	IPCNamespace LinuxNamespaceType = "ipc"
 	// UTSNamespace for isolating hostname and NIS domain name
-	UTSNamespace = "uts"
+	UTSNamespace LinuxNamespaceType = "uts"
 	// UserNamespace for isolating user and group IDs
-	UserNamespace = "user"
+	UserNamespace LinuxNamespaceType = "user"
 	// CgroupNamespace for isolating cgroup hierarchies
-	CgroupNamespace = "cgroup"
+	CgroupNamespace LinuxNamespaceType = "cgroup"
 )
 
 // LinuxIDMapping specifies UID/GID mappings
@@ -217,6 +236,7 @@ type POSIXRlimit struct {
 // LinuxHugepageLimit structure corresponds to limiting kernel hugepages
 type LinuxHugepageLimit struct {
 	// Pagesize is the hugepage size
+	// Format: "<size><unit-prefix>B' (e.g. 64KB, 2MB, 1GB, etc.)
 	Pagesize string `json:"pageSize"`
 	// Limit is the limit of "hugepagesize" hugetlb usage
 	Limit uint64 `json:"limit"`
@@ -288,6 +308,8 @@ type LinuxMemory struct {
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
+	// Enables hierarchical memory accounting
+	UseHierarchy *bool `json:"useHierarchy,omitempty"`
 }
 
 // LinuxCPU for Linux cgroup 'cpu' resource management
@@ -382,6 +404,28 @@ type LinuxDeviceCgroup struct {
 	Minor *int64 `json:"minor,omitempty"`
 	// Cgroup access permissions format, rwm.
 	Access string `json:"access,omitempty"`
+}
+
+// LinuxPersonalityDomain refers to a personality domain.
+type LinuxPersonalityDomain string
+
+// LinuxPersonalityFlag refers to an additional personality flag. None are currently defined.
+type LinuxPersonalityFlag string
+
+// Define domain and flags for Personality
+const (
+	// PerLinux is the standard Linux personality
+	PerLinux LinuxPersonalityDomain = "LINUX"
+	// PerLinux32 sets personality to 32 bit
+	PerLinux32 LinuxPersonalityDomain = "LINUX32"
+)
+
+// LinuxPersonality represents the Linux personality syscall input
+type LinuxPersonality struct {
+	// Domain for the personality
+	Domain LinuxPersonalityDomain `json:"domain"`
+	// Additional flags
+	Flags []LinuxPersonalityFlag `json:"flags,omitempty"`
 }
 
 // Solaris contains platform-specific configuration for Solaris application containers.
@@ -528,7 +572,7 @@ type VMHypervisor struct {
 	// Path is the host path to the hypervisor used to manage the virtual machine.
 	Path string `json:"path"`
 	// Parameters specifies parameters to pass to the hypervisor.
-	Parameters string `json:"parameters,omitempty"`
+	Parameters []string `json:"parameters,omitempty"`
 }
 
 // VMKernel contains information about the kernel to use for a virtual machine.
@@ -536,7 +580,7 @@ type VMKernel struct {
 	// Path is the host path to the kernel used to boot the virtual machine.
 	Path string `json:"path"`
 	// Parameters specifies parameters to pass to the kernel.
-	Parameters string `json:"parameters,omitempty"`
+	Parameters []string `json:"parameters,omitempty"`
 	// InitRD is the host path to an initial ramdisk to be used by the kernel.
 	InitRD string `json:"initrd,omitempty"`
 }
@@ -553,11 +597,15 @@ type VMImage struct {
 type LinuxSeccomp struct {
 	DefaultAction LinuxSeccompAction `json:"defaultAction"`
 	Architectures []Arch             `json:"architectures,omitempty"`
+	Flags         []LinuxSeccompFlag `json:"flags,omitempty"`
 	Syscalls      []LinuxSyscall     `json:"syscalls,omitempty"`
 }
 
 // Arch used for additional architectures
 type Arch string
+
+// LinuxSeccompFlag is a flag to pass to seccomp(2).
+type LinuxSeccompFlag string
 
 // Additional architectures permitted to be used for system calls
 // By default only the native architecture of the kernel is permitted
@@ -592,6 +640,7 @@ const (
 	ActErrno LinuxSeccompAction = "SCMP_ACT_ERRNO"
 	ActTrace LinuxSeccompAction = "SCMP_ACT_TRACE"
 	ActAllow LinuxSeccompAction = "SCMP_ACT_ALLOW"
+	ActLog   LinuxSeccompAction = "SCMP_ACT_LOG"
 )
 
 // LinuxSeccompOperator used to match syscall arguments in Seccomp
@@ -623,10 +672,18 @@ type LinuxSyscall struct {
 	Args   []LinuxSeccompArg  `json:"args,omitempty"`
 }
 
-// LinuxIntelRdt has container runtime resource constraints
-// for Intel RDT/CAT which introduced in Linux 4.10 kernel
+// LinuxIntelRdt has container runtime resource constraints for Intel RDT
+// CAT and MBA features which introduced in Linux 4.10 and 4.12 kernel
 type LinuxIntelRdt struct {
+	// The identity for RDT Class of Service
+	ClosID string `json:"closID,omitempty"`
 	// The schema for L3 cache id and capacity bitmask (CBM)
 	// Format: "L3:<cache_id0>=<cbm0>;<cache_id1>=<cbm1>;..."
 	L3CacheSchema string `json:"l3CacheSchema,omitempty"`
+
+	// The schema of memory bandwidth per L3 cache id
+	// Format: "MB:<cache_id0>=bandwidth0;<cache_id1>=bandwidth1;..."
+	// The unit of memory bandwidth is specified in "percentages" by
+	// default, and in "MBps" if MBA Software Controller is enabled.
+	MemBwSchema string `json:"memBwSchema,omitempty"`
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -8,10 +8,10 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This changes Windows container creation to use the Docker OCI extension
ArgsEscaped to determine how the command to execute should be
interpreted. If ArgsEscaped is set, then the first element of the
command array will be used as-is.

Although this is kind of a gross fix that relies on a non-standard
extension, it is important for the short term to enable certain Docker
images to work with CRI.

Also adds a container creation annotation: microsoft.io/ignore-args-escaped
This can be used to disable the ArgsEscaped checking and new behavior.