### PR TITLE
Add support for binary logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _output/*
 *.exe
 .idea/
+.vscode

--- a/pkg/server/io/container_io_windows.go
+++ b/pkg/server/io/container_io_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package io
+
+import "github.com/containerd/containerd/cio"
+
+// WithBinaryFIFOs specifies binary fifos for the container io
+func WithBinaryFIFOs(path string) ContainerIOOpts {
+	return func(c *ContainerIO) error {
+		fifos := &cio.FIFOSet{
+			Config: cio.Config{
+				Stderr:   path,
+				Stdout:   path,
+			},
+		}
+		c.fifos = fifos
+		return nil
+	}
+}

--- a/pkg/server/io/helpers.go
+++ b/pkg/server/io/helpers.go
@@ -92,3 +92,13 @@ type stdioPipes struct {
 	stdout io.ReadCloser
 	stderr io.ReadCloser
 }
+
+func newEmptyPipes() (*stdioPipes, *wgCloser) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &stdioPipes{}, &wgCloser{
+		wg:     &sync.WaitGroup{},
+		set:    []io.Closer{},
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}


### PR DESCRIPTION
This PR adds support for providing a custom binary logger via `log_path` container config.

As also described in https://github.com/microsoft/hcsshim/pull/896,
if `log_path` contains a `binary://` scheme, `ctr-x-stdout/stderr` won't
be created anymore, and it becomes hcsshim's responsibility to route
container IO to the binary.

Signed-off-by: Maksim An <maksiman@microsoft.com>