### PR TITLE
Parse container stop signal based on sandbox platform

### DIFF
--- a/pkg/server/helpers_unix.go
+++ b/pkg/server/helpers_unix.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/containerd/containerd/platforms"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
@@ -64,4 +65,8 @@ func checkSelinuxLevel(level string) (bool, error) {
 		return false, errors.Wrapf(err, "the format of 'level' %q is not correct", level)
 	}
 	return true, nil
+}
+
+func (c *criService) getSandboxPlatform(_ string) (string, error) {
+	return platforms.DefaultString(), nil
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -3,7 +3,7 @@ github.com/blang/semver v3.1.0
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups caf71576c8b19daf80ab4685916e4d5b4c74887e
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd 12e49bbd4d6124ebdbbc3f66919416f360b46dda https://github.com/kevpar/containerd.git # fork/release/1.4
+github.com/containerd/containerd 4fd5652678e9650bfefd3a8de1e697e84c25844b https://github.com/kevpar/containerd.git # fork/release/1.4
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90

--- a/vendor/github.com/containerd/containerd/signals.go
+++ b/vendor/github.com/containerd/containerd/signals.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -48,10 +49,6 @@ func GetStopSignal(ctx context.Context, container Container, defaultSignal sysca
 
 // GetOCIStopSignal retrieves the stop signal specified in the OCI image config
 func GetOCIStopSignal(ctx context.Context, image Image, defaultSignal string) (string, error) {
-	_, err := ParseSignal(defaultSignal)
-	if err != nil {
-		return "", err
-	}
 	ic, err := image.Config(ctx)
 	if err != nil {
 		return "", err
@@ -59,6 +56,7 @@ func GetOCIStopSignal(ctx context.Context, image Image, defaultSignal string) (s
 	var (
 		ociimage v1.Image
 		config   v1.ImageConfig
+		platform string = platforms.DefaultSpec().OS
 	)
 	switch ic.MediaType {
 	case v1.MediaTypeImageConfig, images.MediaTypeDockerSchema2Config:
@@ -71,8 +69,14 @@ func GetOCIStopSignal(ctx context.Context, image Image, defaultSignal string) (s
 			return "", err
 		}
 		config = ociimage.Config
+		platform = ociimage.OS
 	default:
 		return "", fmt.Errorf("unknown image config media type %s", ic.MediaType)
+	}
+
+	// verify that default signal is valid
+	if _, err := ParsePlatformSignal(defaultSignal, platform); err != nil {
+		return "", err
 	}
 
 	if config.StopSignal == "" {

--- a/vendor/github.com/containerd/containerd/signals_unix.go
+++ b/vendor/github.com/containerd/containerd/signals_unix.go
@@ -31,6 +31,14 @@ import (
 // the rawSignal can be a string with "SIG" prefix,
 // or a signal number in string format.
 func ParseSignal(rawSignal string) (syscall.Signal, error) {
+	return parseSignalUnix(rawSignal)
+}
+
+func ParsePlatformSignal(rawSignal string, _ string) (syscall.Signal, error) {
+	return parseSignalUnix(rawSignal)
+}
+
+func parseSignalUnix(rawSignal string) (syscall.Signal, error) {
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
 		return syscall.Signal(s), nil

--- a/vendor/github.com/containerd/containerd/signals_windows.go
+++ b/vendor/github.com/containerd/containerd/signals_windows.go
@@ -25,39 +25,136 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-var signalMap = map[string]syscall.Signal{
-	"HUP":    syscall.Signal(windows.SIGHUP),
-	"INT":    syscall.Signal(windows.SIGINT),
-	"QUIT":   syscall.Signal(windows.SIGQUIT),
-	"SIGILL": syscall.Signal(windows.SIGILL),
-	"TRAP":   syscall.Signal(windows.SIGTRAP),
-	"ABRT":   syscall.Signal(windows.SIGABRT),
-	"BUS":    syscall.Signal(windows.SIGBUS),
-	"FPE":    syscall.Signal(windows.SIGFPE),
-	"KILL":   syscall.Signal(windows.SIGKILL),
-	"SEGV":   syscall.Signal(windows.SIGSEGV),
-	"PIPE":   syscall.Signal(windows.SIGPIPE),
-	"ALRM":   syscall.Signal(windows.SIGALRM),
-	"TERM":   syscall.Signal(windows.SIGTERM),
+const (
+	linuxSigrtmin = 34
+	linuxSigrtmax = 64
+)
+
+var signalMapWindows = map[string]syscall.Signal{
+	"HUP":  syscall.Signal(windows.SIGHUP),
+	"INT":  syscall.Signal(windows.SIGINT),
+	"QUIT": syscall.Signal(windows.SIGQUIT),
+	"ILL":  syscall.Signal(windows.SIGILL),
+	"TRAP": syscall.Signal(windows.SIGTRAP),
+	"ABRT": syscall.Signal(windows.SIGABRT),
+	"BUS":  syscall.Signal(windows.SIGBUS),
+	"FPE":  syscall.Signal(windows.SIGFPE),
+	"KILL": syscall.Signal(windows.SIGKILL),
+	"SEGV": syscall.Signal(windows.SIGSEGV),
+	"PIPE": syscall.Signal(windows.SIGPIPE),
+	"ALRM": syscall.Signal(windows.SIGALRM),
+	"TERM": syscall.Signal(windows.SIGTERM),
+}
+
+// manually define signals for linux since we may be running an LCOW container, but
+// the unix syscalls do not get built when running on windows
+var signalMapLinux = map[string]syscall.Signal{
+	"ABRT":     syscall.Signal(0x6),
+	"ALRM":     syscall.Signal(0xe),
+	"BUS":      syscall.Signal(0x7),
+	"CHLD":     syscall.Signal(0x11),
+	"CLD":      syscall.Signal(0x11),
+	"CONT":     syscall.Signal(0x12),
+	"FPE":      syscall.Signal(0x8),
+	"HUP":      syscall.Signal(0x1),
+	"ILL":      syscall.Signal(0x4),
+	"INT":      syscall.Signal(0x2),
+	"IO":       syscall.Signal(0x1d),
+	"IOT":      syscall.Signal(0x6),
+	"KILL":     syscall.Signal(0x9),
+	"PIPE":     syscall.Signal(0xd),
+	"POLL":     syscall.Signal(0x1d),
+	"PROF":     syscall.Signal(0x1b),
+	"PWR":      syscall.Signal(0x1e),
+	"QUIT":     syscall.Signal(0x3),
+	"SEGV":     syscall.Signal(0xb),
+	"STKFLT":   syscall.Signal(0x10),
+	"STOP":     syscall.Signal(0x13),
+	"SYS":      syscall.Signal(0x1f),
+	"TERM":     syscall.Signal(0xf),
+	"TRAP":     syscall.Signal(0x5),
+	"TSTP":     syscall.Signal(0x14),
+	"TTIN":     syscall.Signal(0x15),
+	"TTOU":     syscall.Signal(0x16),
+	"URG":      syscall.Signal(0x17),
+	"USR1":     syscall.Signal(0xa),
+	"USR2":     syscall.Signal(0xc),
+	"VTALRM":   syscall.Signal(0x1a),
+	"WINCH":    syscall.Signal(0x1c),
+	"XCPU":     syscall.Signal(0x18),
+	"XFSZ":     syscall.Signal(0x19),
+	"RTMIN":    linuxSigrtmin,
+	"RTMIN+1":  linuxSigrtmin + 1,
+	"RTMIN+2":  linuxSigrtmin + 2,
+	"RTMIN+3":  linuxSigrtmin + 3,
+	"RTMIN+4":  linuxSigrtmin + 4,
+	"RTMIN+5":  linuxSigrtmin + 5,
+	"RTMIN+6":  linuxSigrtmin + 6,
+	"RTMIN+7":  linuxSigrtmin + 7,
+	"RTMIN+8":  linuxSigrtmin + 8,
+	"RTMIN+9":  linuxSigrtmin + 9,
+	"RTMIN+10": linuxSigrtmin + 10,
+	"RTMIN+11": linuxSigrtmin + 11,
+	"RTMIN+12": linuxSigrtmin + 12,
+	"RTMIN+13": linuxSigrtmin + 13,
+	"RTMIN+14": linuxSigrtmin + 14,
+	"RTMIN+15": linuxSigrtmin + 15,
+	"RTMAX-14": linuxSigrtmax - 14,
+	"RTMAX-13": linuxSigrtmax - 13,
+	"RTMAX-12": linuxSigrtmax - 12,
+	"RTMAX-11": linuxSigrtmax - 11,
+	"RTMAX-10": linuxSigrtmax - 10,
+	"RTMAX-9":  linuxSigrtmax - 9,
+	"RTMAX-8":  linuxSigrtmax - 8,
+	"RTMAX-7":  linuxSigrtmax - 7,
+	"RTMAX-6":  linuxSigrtmax - 6,
+	"RTMAX-5":  linuxSigrtmax - 5,
+	"RTMAX-4":  linuxSigrtmax - 4,
+	"RTMAX-3":  linuxSigrtmax - 3,
+	"RTMAX-2":  linuxSigrtmax - 2,
+	"RTMAX-1":  linuxSigrtmax - 1,
+	"RTMAX":    linuxSigrtmax,
 }
 
 // ParseSignal parses a given string into a syscall.Signal
 // the rawSignal can be a string with "SIG" prefix,
 // or a signal number in string format.
 func ParseSignal(rawSignal string) (syscall.Signal, error) {
+	return parseSignalGeneric(rawSignal, "windows")
+}
+
+// ParsePlatformSignal parses a given string into a syscall.Signal based on
+// the OS platform specified in `platform`.
+func ParsePlatformSignal(rawSignal, platform string) (syscall.Signal, error) {
+	return parseSignalGeneric(rawSignal, platform)
+}
+
+func parseSignalGeneric(rawSignal, platform string) (syscall.Signal, error) {
+	signalMap := getSignalMapForPlatform(platform)
 	s, err := strconv.Atoi(rawSignal)
 	if err == nil {
 		sig := syscall.Signal(s)
+		if platform != "windows" {
+			return sig, nil
+		}
+		// on windows, make sure we support this signal
 		for _, msig := range signalMap {
 			if sig == msig {
 				return sig, nil
 			}
 		}
-		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+		return sig, fmt.Errorf("unknown signal %q", rawSignal)
 	}
 	signal, ok := signalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
 	if !ok {
 		return -1, fmt.Errorf("unknown signal %q", rawSignal)
 	}
 	return signal, nil
+}
+
+func getSignalMapForPlatform(platform string) map[string]syscall.Signal {
+	if platform != "windows" {
+		return signalMapLinux
+	}
+	return signalMapWindows
 }

--- a/vendor/github.com/gogo/protobuf/go.mod
+++ b/vendor/github.com/gogo/protobuf/go.mod
@@ -1,5 +1,7 @@
 module github.com/gogo/protobuf
 
+go 1.14
+
 require (
 	github.com/kisielk/errcheck v1.2.0 // indirect
 	github.com/kisielk/gotool v1.0.0 // indirect


### PR DESCRIPTION
This PR fixes an issue for LCOW where container stop signals are parsed based on the host machine platform instead of on the sandbox's platform. This caused an issue where LCOW stop signals would be parsed as windows signals and thus would be considered invalid. 