### PR TITLE
Cherry pick work needed to support remote snapshotters

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,11 @@ type ContainerdConfig struct {
 	// This only works for runtime type "io.containerd.runtime.v1.linux".
 	// DEPRECATED: use Runtime.Options instead. Remove when shim v1 is deprecated.
 	NoPivot bool `toml:"no_pivot" json:"noPivot"`
+
+	// DisableSnapshotAnnotations disables to pass additional annotations (image
+	// related information) to snapshotters. These annotations are required by
+	// stargz snapshotter (https://github.com/containerd/stargz-snapshotter).
+	DisableSnapshotAnnotations bool `toml:"disable_snapshot_annotations" json:"disableSnapshotAnnotations"`
 }
 
 // CniConfig contains toml config related to cni

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/labels"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/reference"
 	"github.com/containerd/containerd/remotes"
@@ -348,9 +349,12 @@ const (
 	// targetRefLabel is a label which contains image reference and will be passed
 	// to snapshotters.
 	targetRefLabel = "containerd.io/snapshot/cri.image-ref"
-	// targetDigestLabel is a label which contains layer digest and will be passed
+	// targetManifestDigestLabel is a label which contains manifest digest and will be passed
 	// to snapshotters.
-	targetDigestLabel = "containerd.io/snapshot/cri.layer-digest"
+	targetManifestDigestLabel = "containerd.io/snapshot/cri.manifest-digest"
+	// targetLayerDigestLabel is a label which contains layer digest and will be passed
+	// to snapshotters.
+	targetLayerDigestLabel = "containerd.io/snapshot/cri.layer-digest"
 	// targetImageLayersLabel is a label which contains layer digests contained in
 	// the target image and will be passed to snapshotters for preparing layers in
 	// parallel.
@@ -358,8 +362,8 @@ const (
 )
 
 // appendInfoHandlerWrapper makes a handler which appends some basic information
-// of images to each layer descriptor as annotations during unpack. These
-// annotations will be passed to snapshotters as labels. These labels will be
+// of images like digests for manifest and their child layers as annotations during unpack.
+// These annotations will be passed to snapshotters as labels. These labels will be
 // used mainly by stargz-based snapshotters for querying image contents from the
 // registry.
 func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) containerdimages.Handler {
@@ -387,8 +391,9 @@ func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) conta
 							c.Annotations = make(map[string]string)
 						}
 						c.Annotations[targetRefLabel] = ref
-						c.Annotations[targetDigestLabel] = c.Digest.String()
-						c.Annotations[targetImageLayersLabel] = layers
+						c.Annotations[targetLayerDigestLabel] = c.Digest.String()
+						c.Annotations[targetImageLayersLabel] = getLayers(ctx, targetImageLayersLabel, children[i:], labels.Validate)
+						c.Annotations[targetManifestDigestLabel] = desc.Digest.String()
 					}
 				}
 			}

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -110,7 +110,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	pullOpts := []containerd.RemoteOpt{
 		containerd.WithSchema1Conversion,
 		containerd.WithResolver(resolver),
-		containerd.WithPullSnapshotter(c.config.ContainerdConfig.Snapshotter),
+		containerd.WithPullSnapshotter(c.getDefaultSnapshotterForSandbox(r.GetSandboxConfig())),
 		containerd.WithPullUnpack,
 		containerd.WithPullLabel(imageLabelKey, imageLabelValue),
 		containerd.WithImageHandler(imageHandler),
@@ -357,7 +357,7 @@ const (
 	targetLayerDigestLabel = "containerd.io/snapshot/cri.layer-digest"
 	// targetImageLayersLabel is a label which contains layer digests contained in
 	// the target image and will be passed to snapshotters for preparing layers in
-	// parallel.
+	// parallel. Skipping some layers is allowed and only affects performance.
 	targetImageLayersLabel = "containerd.io/snapshot/cri.image-layers"
 )
 
@@ -375,15 +375,6 @@ func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) conta
 			}
 			switch desc.MediaType {
 			case imagespec.MediaTypeImageManifest, containerdimages.MediaTypeDockerSchema2Manifest:
-				var layers string
-				for _, c := range children {
-					if containerdimages.IsLayerType(c.MediaType) {
-						layers += fmt.Sprintf("%s,", c.Digest.String())
-					}
-				}
-				if len(layers) >= 1 {
-					layers = layers[:len(layers)-1]
-				}
 				for i := range children {
 					c := &children[i]
 					if containerdimages.IsLayerType(c.MediaType) {
@@ -400,4 +391,26 @@ func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) conta
 			return children, nil
 		})
 	}
+}
+
+// getLayers returns comma-separated digests based on the passed list of
+// descriptors. The returned list contains as many digests as possible as well
+// as meets the label validation.
+func getLayers(ctx context.Context, key string, descs []imagespec.Descriptor, validate func(k, v string) error) (layers string) {
+	var item string
+	for _, l := range descs {
+		if containerdimages.IsLayerType(l.MediaType) {
+			item = l.Digest.String()
+			if layers != "" {
+				item = "," + item
+			}
+			// This avoids the label hits the size limitation.
+			if err := validate(key, layers+item); err != nil {
+				log.G(ctx).WithError(err).WithField("label", key).Debugf("%q is omitted in the layers list", l.Digest.String())
+				break
+			}
+			layers += item
+		}
+	}
+	return
 }

--- a/pkg/server/image_pull_test.go
+++ b/pkg/server/image_pull_test.go
@@ -17,9 +17,14 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
+	digest "github.com/opencontainers/go-digest"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -127,5 +132,50 @@ func TestCredentials(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, test.expectedUsername, username)
 		assert.Equal(t, test.expectedPassword, password)
+	}
+}
+
+func TestImageLayersLabel(t *testing.T) {
+	sampleKey := "sampleKey"
+	sampleDigest, err := digest.Parse("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	assert.NoError(t, err)
+	sampleMaxSize := 300
+	sampleValidate := func(k, v string) error {
+		if (len(k) + len(v)) > sampleMaxSize {
+			return fmt.Errorf("invalid: %q: %q", k, v)
+		}
+		return nil
+	}
+
+	tests := []struct {
+		name      string
+		layersNum int
+		wantNum   int
+	}{
+		{
+			name:      "valid number of layers",
+			layersNum: 2,
+			wantNum:   2,
+		},
+		{
+			name:      "many layers",
+			layersNum: 5, // hits sampleMaxSize (300 chars).
+			wantNum:   4, // layers should be ommitted for avoiding invalid label.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sampleLayers []imagespec.Descriptor
+			for i := 0; i < tt.layersNum; i++ {
+				sampleLayers = append(sampleLayers, imagespec.Descriptor{
+					MediaType: imagespec.MediaTypeImageLayerGzip,
+					Digest:    sampleDigest,
+				})
+			}
+			gotS := getLayers(context.Background(), sampleKey, sampleLayers, sampleValidate)
+			got := len(strings.Split(gotS, ","))
+			assert.Equal(t, tt.wantNum, got)
+		})
 	}
 }


### PR DESCRIPTION
Cherry-pick in the following from upstream:
ba8ad15aebfdf6218e6374dd24ffc5f5f5ed2cf5
1dc3b8a7396e110ac0f0bc48df9c7cb46399f400
ca661c8dc968e952b323a3d836efa41a8481f907
c1b7bcf395d1334333e254ead5b6cd7dfa84cbb9
d64fa3b6b861617e60416bf640a52fc9657826ab

These additions make it so that snapshotters get passed annotations containing the image ref, layer/manifest digests and individual layer digest for the snapshot being made. This is needed for remote snapshotters to function.