### PR TITLE
pkg/server/io: windows: Make delayedConnection cancelable

### DIFF
--- a/pkg/server/io/helpers_windows.go
+++ b/pkg/server/io/helpers_windows.go
@@ -25,52 +25,111 @@ import (
 
 	winio "github.com/Microsoft/go-winio"
 	"github.com/containerd/containerd/cio"
-	"github.com/containerd/containerd/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
+// delayedConnection is a io.ReadWriteCloser that takes a net.Listener, calls Accept on it, and
+// then blocks any Read/Write/Close operations until a connection has been established. It is
+// created by calling newDelayedConnection, and the context.Context passed to that function can
+// be canceled to abort the Accept call.
 type delayedConnection struct {
-	l    net.Listener
-	con  net.Conn
-	wg   sync.WaitGroup
-	once sync.Once
+	con net.Conn
+	// listenDoneCh is closed when listening is complete. This means the delayedConnection
+	// will either be in a connected state, or an error state.
+	listenDoneCh chan struct{}
+	listenErr    error
+	// closeCh is closed to indicate to waitListener that listening should be aborted.
+	closeCh chan struct{}
 }
 
 func (dc *delayedConnection) Write(p []byte) (int, error) {
-	dc.wg.Wait()
-	if dc.con != nil {
-		return dc.con.Write(p)
+	<-dc.listenDoneCh
+	if dc.listenErr != nil {
+		return 0, errors.Wrap(dc.listenErr, "connection failed")
 	}
-	return 0, errors.New("use of closed network connection")
+	return dc.con.Write(p)
 }
 
 func (dc *delayedConnection) Read(p []byte) (int, error) {
-	dc.wg.Wait()
-	if dc.con != nil {
-		return dc.con.Read(p)
+	<-dc.listenDoneCh
+	if dc.listenErr != nil {
+		return 0, errors.Wrap(dc.listenErr, "connection failed")
 	}
-	return 0, errors.New("use of closed network connection")
+	return dc.con.Read(p)
 }
 
-func (dc *delayedConnection) unblockConnectionWaiters() {
-	defer dc.once.Do(func() {
-		dc.wg.Done()
-	})
+// waitListener runs as a separate goroutine and manages the listener
+// for the delayedConnection.
+func (dc *delayedConnection) waitListener(ctx context.Context, l net.Listener) {
+	// We block this entire function on Accept below, and only unblock when either the
+	// listener successfully connects, or if an error is encountered.
+	// We can force unblock the Accept by closing the listener, which is done by the
+	// goroutine below in several cases.
+	ch := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done(): // Context hit deadline or canceled.
+		case <-dc.closeCh: // Close was called.
+		case <-ch: // Accept finished properly.
+		}
+		l.Close()
+	}()
+	con, acceptErr := l.Accept()
+	// Unblock the goroutine above. It's okay for it to close the listener now, we don't need it
+	// anymore.
+	close(ch)
+	if err := ctx.Err(); err != nil {
+		// If the context was canceled, use its error instead of the one from Accept. This ensures
+		// Read/Write will return an error like "connection failed: context deadline exceeded".
+		dc.listenErr = err
+		if con != nil {
+			con.Close()
+		}
+	} else {
+		// Otherwise, use the con/err returned from Accept. In the case where Accept was unblocked
+		// by closing the listener, error should be something like "use of closed network connection".
+		dc.con = con
+		dc.listenErr = acceptErr
+	}
+	// Unblock anyone waiting for listening to be done.
+	close(dc.listenDoneCh)
 }
 
 func (dc *delayedConnection) Close() error {
-	dc.l.Close()
-	if dc.con != nil {
-		return dc.con.Close()
+	// If we have already closed closeCh, then all the work is already done. Just return an
+	// "already closed" error.
+	select {
+	case <-dc.closeCh:
+		return errors.New("connection is already closed")
+	default:
 	}
-	dc.unblockConnectionWaiters()
-	return nil
+	close(dc.closeCh)
+	<-dc.listenDoneCh
+	var err error
+	if dc.con != nil {
+		err = dc.con.Close()
+	}
+	return err
+}
+
+func newDelayedConnection(ctx context.Context, path string) (io.ReadWriteCloser, error) {
+	l, err := winio.ListenPipe(path, nil)
+	if err != nil {
+		return nil, err
+	}
+	dc := &delayedConnection{
+		listenDoneCh: make(chan struct{}),
+		closeCh:      make(chan struct{}),
+	}
+	go dc.waitListener(ctx, l)
+	return dc, nil
 }
 
 // newStdioPipes creates actual fifos for stdio.
 func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 	var (
+		f           io.ReadWriteCloser
 		set         []io.Closer
 		ctx, cancel = context.WithCancel(context.Background())
 		p           = &stdioPipes{}
@@ -85,90 +144,27 @@ func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
 	}()
 
 	if fifos.Stdin != "" {
-		l, err := winio.ListenPipe(fifos.Stdin, nil)
-		if err != nil {
+		if f, err = newDelayedConnection(ctx, fifos.Stdin); err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to create stdin pipe %s", fifos.Stdin)
 		}
-		dc := &delayedConnection{
-			l: l,
-		}
-		dc.wg.Add(1)
-		defer func() {
-			if err != nil {
-				dc.Close()
-			}
-		}()
-		set = append(set, l)
-		p.stdin = dc
-
-		go func() {
-			c, err := l.Accept()
-			if err != nil {
-				dc.Close()
-				log.L.WithError(err).Errorf("failed to accept stdin connection on %s", fifos.Stdin)
-				return
-			}
-			dc.con = c
-			dc.unblockConnectionWaiters()
-		}()
+		p.stdin = f
+		set = append(set, f)
 	}
 
 	if fifos.Stdout != "" {
-		l, err := winio.ListenPipe(fifos.Stdout, nil)
-		if err != nil {
+		if f, err = newDelayedConnection(ctx, fifos.Stdout); err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to create stdout pipe %s", fifos.Stdout)
 		}
-		dc := &delayedConnection{
-			l: l,
-		}
-		dc.wg.Add(1)
-		defer func() {
-			if err != nil {
-				dc.Close()
-			}
-		}()
-		set = append(set, l)
-		p.stdout = dc
-
-		go func() {
-			c, err := l.Accept()
-			if err != nil {
-				dc.Close()
-				log.L.WithError(err).Errorf("failed to accept stdout connection on %s", fifos.Stdout)
-				return
-			}
-			dc.con = c
-			dc.unblockConnectionWaiters()
-		}()
+		p.stdout = f
+		set = append(set, f)
 	}
 
 	if fifos.Stderr != "" {
-		l, err := winio.ListenPipe(fifos.Stderr, nil)
-		if err != nil {
+		if f, err = newDelayedConnection(ctx, fifos.Stderr); err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to create stderr pipe %s", fifos.Stderr)
 		}
-		dc := &delayedConnection{
-			l: l,
-		}
-		dc.wg.Add(1)
-		defer func() {
-			if err != nil {
-				dc.Close()
-			}
-		}()
-		set = append(set, l)
-		p.stderr = dc
-
-		go func() {
-			c, err := l.Accept()
-			if err != nil {
-				dc.Close()
-				log.L.WithError(err).Errorf("failed to accept stderr connection on %s", fifos.Stderr)
-				return
-			}
-			dc.con = c
-			dc.unblockConnectionWaiters()
-		}()
+		p.stderr = f
+		set = append(set, f)
 	}
 
 	return p, &wgCloser{


### PR DESCRIPTION
This commit largely rewrites the delayedConnection type to make it more
robust, and able to abort waiting for a connection via canceling the
context.Context that is passed in to newDelayedConnection.

delayedConnection now utilizes a separate goroutine, waitListener, to
manage the listener lifecycle. waitListener calls Accept on the
listener, but also runs another goroutine that waits for various signals
via channels (e.g. ctx.Done()), and closes the listener to unblock the
Accept.

This is important to resolve an issue when restarting containerd with a
container that stopped while containerd was down:
- containerd starts and reloads the container by connecting to the Task.
  As part of the task IO, the listener is created and Accept is called.
  This Accept call never completes as the container has already stopped.
- containerd notices the task is in exited state, so it calls Delete on
  the task.
- Task.Delete calls Cancel on the IO, which cancels the context that was
  created in newStdioPipes, but this context is not hooked up to
  anything so it does nothing.
- Task.Delete calls Wait on the IO, which waits forever because the
  Accept never completes.
- This causes CRI to become stuck on initialization and return the
  "server is not initialized yet" error.

With this fix, the Cancel call on the IO will now properly abort the
Accept call, which resolves the issue.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>