### PR TITLE
Add option to disallow pulling the same image in parallel for cri

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,11 @@ type ContainerdConfig struct {
 	// remove layers from the content store after successfully unpacking these
 	// layers to the snapshotter.
 	DiscardUnpackedLayers bool `toml:"discard_unpacked_layers" json:"discardUnpackedLayers"`
+
+	// DisableSameImageParallelPull disables the ability to pull the exact same image in parallel which is a common
+	// operation on Kubernetes nodes. This saves some unneccessary fetch/unpack work as it's just duplicated effort
+	// for no gain.
+	DisableSameImageParallelPull bool `toml:"disable_same_image_parallel_pull" json:"disableSameImageParallelPull"`
 }
 
 // CniConfig contains toml config related to cni

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -99,6 +99,9 @@ type criService struct {
 	// initialized indicates whether the server is initialized. All GRPC services
 	// should return error before the server is initialized.
 	initialized atomic.Bool
+	// imagesInProgress represents any images currently being pulled. This can be used to deduplicate
+	// pulls of the same image to save work.
+	imagesInProgress *inProgress
 }
 
 // NewCRIService returns a new instance of CRIService


### PR DESCRIPTION
Starting multiple pods on a single node, all using the same image and when the image isn't already present
on the node has pretty awful performance (especially on Windows, as unpack isn't cheap). This
change adds an option to skip this, by keeping an in memory cache of in progress pulls at the cri layer.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>