### PR TITLE
Terminate running containers when CRI restarts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -163,6 +163,8 @@ type PluginConfig struct {
 	RestrictOOMScoreAdj bool `toml:"restrict_oom_score_adj" json:"restrictOOMScoreAdj"`
 	// Sets GODEBUG=http2client=0 if enabled.
 	DisableHTTP2Client bool `toml:"disable_http2_client" json:"disableHTTP2Client"`
+	// Determines whether any running containers should be terminated when CRI shuts down or starts up.
+	TerminateContainersOnRestart bool `toml:"terminate_containers_on_restart" json:"terminateContainersOnRestart"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,7 +32,6 @@ import (
 	cni "github.com/containerd/go-cni"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"


### PR DESCRIPTION
Currently if any containers are still running when CRI restarts, we are
unable to reconnect to their IO pipes. Due to this, the containers can
get stuck if they do blocking IO operations, as the pipes are not being
drained by CRI anymore.

There is longer-term work to reconnect to the IO pipes, but for the
meantime, this change makes CRI terminate any running containers in two
cases:
- When CRI gracefully shuts down
- When CRI starts up, as it rediscovers running containers

This change also improves logging a little in the restart logic.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>